### PR TITLE
Fix missing error if initial connection cannot be established.

### DIFF
--- a/dcom/rpc/stub.js
+++ b/dcom/rpc/stub.js
@@ -87,7 +87,7 @@ class Stub extends Events.EventEmitter {
     transport = this.endpoint.transport;
     await transport.attach()
     .catch(function(reject) {
-      debug(reject);
+      throw new Error(reject)
     });
   }
 

--- a/dcom/transport/comtransport.js
+++ b/dcom/transport/comtransport.js
@@ -108,6 +108,7 @@ class ComTransport extends events.EventEmitter
 
       channel.on('error', function(data){
         self.emit('disconnected');
+        reject(data)
       });
 
       channel.on('close', function(){
@@ -116,7 +117,10 @@ class ComTransport extends events.EventEmitter
         }
       });
 
+      const connectFailedTimer = setTimeout(() =>
+        channel.emit('error', 'Connection could not be established'), self.timeout)
       channel.connect(Number.parseInt(self.port),  self.host, () => {
+        clearTimeout(connectFailedTimer)
         self.attached = true;
         channel.setKeepAlive(true);
         self.channelWrapper = channel;

--- a/dcom/transport/comtransport.js
+++ b/dcom/transport/comtransport.js
@@ -117,7 +117,7 @@ class ComTransport extends events.EventEmitter
         }
       });
 
-      const connectFailedTimer = setTimeout(() =>
+      const connectFailedTimer = self.timeout && setTimeout(() =>
         channel.emit('error', 'Connection could not be established'), self.timeout)
       channel.connect(Number.parseInt(self.port),  self.host, () => {
         clearTimeout(connectFailedTimer)


### PR DESCRIPTION
Use case: If you try to create a connection to a DCOM server (OPCDA Server in my example), but misspelled the IP address. Currently the socket setup just runs forever, but we already have a timeout setting and also an `error` event which we only have to use. 

Proposed solution: Add a timer that lets the ComTransport object emit an `error` event if the timeout times out before the socket has connected, otherwise clear the timeout again immediately.