### PR TITLE
Add example script for initial connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ typings/
 
 # Visual Studio Code config folder
 .vscode
+package-lock.json

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,0 +1,31 @@
+const { Session, Clsid, ComServer } = require('../dcom')
+
+const domain = 'WORKGROUP'
+const username = 'myuser'
+const password = 'mypassword'
+const ipAddress = '1.2.3.4'
+const timeout = 1000
+const classIdString = 'F8582CF2-88FB-11D0-B850-00C0F0104305' // Matrikon.OPC.Simulation
+
+const sessionSingleton = new Session()
+
+async function main () {
+  const comSession = sessionSingleton.createSession(domain, username, password)
+  comSession.setGlobalSocketTimeout(timeout)
+  const clsid = new Clsid(classIdString)
+  const comServer = new ComServer(clsid, ipAddress, comSession, { major: 5, minor: 7 })
+
+  try {
+    // start the COM Server
+    await comServer.init()
+    console.log(`Successfully connected to ${ipAddress}`)
+
+    await comServer.closeStub()
+  } catch (err) {
+    console.trace(err)
+  }
+
+  await comSession.destroySession(comSession)
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple lib to support DCOM communication (Heavly based on J-Interop)",
   "main": "dcom/index.js",
   "scripts": {
-    "test": "none"
+    "test": "node examples/example.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The README explains an example sequence of commands, but the package is still missing an actual example. This PR adds such an example for initial connection, and for simplicity, it is also made accessible by just calling "npm test". 

This could be an actual automated test for the case of an unreachable IP address. For testing a reachable IP address, of course the actual server is needed, so that would not be part of a fully automated test for now.