### PR TITLE
fix: can not write tag with data type is date time

### DIFF
--- a/dcom/core/variant.js
+++ b/dcom/core/variant.js
@@ -784,7 +784,7 @@ class VariantBody
       throw new Error(new ErrorCodes().VARIANT_UNSUPPORTED_TYPE);
     }
 
-    if (dataType == variantTypes.VT_NULL) {
+    if (this.types == variantTypes.VT_NULL) {
       this.isNull = true;
       this.obj = new Number(0);
     }


### PR DESCRIPTION
Because types of date time is 1 and variantTypes.VT_NULL also 1, so when we try to write value for date time tag, it all way match with VT_NULL, obj was reset to new Number(0)
This fix change to use this.types instead of dataType